### PR TITLE
Add workflow_dispatch and homepage to config files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "homepage": "https://johnjmjensen.github.io/gentest/",
   "name": "gentest",
   "private": true,
   "version": "0.0.0",


### PR DESCRIPTION
Enabled manual triggering of the deploy GitHub Actions workflow by adding workflow_dispatch. Set the homepage field in package.json for correct deployment URL.